### PR TITLE
Fix Bug: The metrics-server image pull strategy is always

### DIFF
--- a/adaptor/v1alpha1/rke_cluster.go
+++ b/adaptor/v1alpha1/rke_cluster.go
@@ -175,6 +175,9 @@ func GetDefaultRKECreateClusterConfig(config KubernetesClusterConfig) CreateClus
 		Ingress: v3.IngressConfig{
 			Provider: "none",
 		},
+		Monitoring: v3.MonitoringConfig{
+			Provider: "none",
+		},
 	}
 	return rkeConfig
 }


### PR DESCRIPTION
Bug Detail:
- The metrics-server image pull strategy is always, which causes the offline environment to fail to pull the image

Reason:
- refer to: https://github.com/rancher/rke/issues/1356
- When rke installs the cluster, the metrics-server image pull strategy is always and cannot be configured

Solution:
- refer to: https://rancher.com/docs/rke/latest/en/config-options/add-ons/metrics-server/
- Disable rke to install metrics-server, use rbd-operator to install
