### PR TITLE
Bug Fix: check api healthy

### DIFF
--- a/internal/task/init_rainbond_cluster.go
+++ b/internal/task/init_rainbond_cluster.go
@@ -29,7 +29,6 @@ import (
 	"runtime/debug"
 	"time"
 
-	"github.com/goodrain/rainbond-operator/api/v1alpha1"
 	rainbondv1alpha1 "github.com/goodrain/rainbond-operator/api/v1alpha1"
 	"github.com/goodrain/rainbond-operator/util/retryutil"
 	"github.com/nsqio/go-nsq"
@@ -205,7 +204,7 @@ func (c *InitRainbondCluster) Run(ctx context.Context) {
 			continue
 		}
 
-		idx, condition := status.RainbondCluster.Status.GetCondition(v1alpha1.RainbondClusterConditionTypeRunning)
+		idx, condition := status.RainbondCluster.Status.GetCondition(rainbondv1alpha1.RainbondClusterConditionTypeRunning)
 		if idx != -1 && condition.Status == v1.ConditionTrue && status.RegionConfig != nil && packageMessage && !apiReadyMessage {
 			if err := checkAPIHealthy(status.RegionConfig); err != nil {
 				c.rollback("InitRainbondRegionRegionConfig", err.Error(), "failure")


### PR DESCRIPTION
### Bug Detail

1. checkAPIHealthy 不同时, InitRainbondRegionRegionConfig事件一直不会结束.
2. InitRainbondRegionPackage 事件的开始与实际不符, 镜像仓库还没装出来 InitRainbondRegionPackage 就是 success 了

### Solution

1. 通过 RainbondClusterConditionTypeRunning 判断集群是否已经安装完成, 处于运行中. 集群处于运行中后, 对 api 进行检测, 会有 3 次的重试机会, 如果 api 检测失败了, InitRainbondRegionRegionConfig 就会被设置为 failure, 结束安装过程.
2. 通过 RainbondClusterConditionTypeImageRepository 去判断私有镜像仓库是否 ready, 然后才开始 InitRainbondRegionPackage