### PR TITLE
bug fix: etcd perm conflict

### DIFF
--- a/internal/model/cloud.go
+++ b/internal/model/cloud.go
@@ -53,8 +53,10 @@ type InitRainbondTask struct {
 //UpdateKubernetesTask -
 type UpdateKubernetesTask struct {
 	Model
-	TaskID       string `gorm:"column:task_id" json:"taskID"`
-	ClusterID    string `gorm:"column:cluster_id" json:"clusterID"`
+	TaskID    string `gorm:"column:task_id" json:"taskID"`
+	ClusterID string `gorm:"column:cluster_id;uniqueIndex:version;" json:"clusterID"`
+	// Version for optimistic lock
+	Version      int    `gorm:"column:version;uniqueIndex:version;" json:"version"`
 	Provider     string `gorm:"column:provider_name" json:"providerName"`
 	NodeNumber   int    `gorm:"column:node_number" json:"nodeNumber"`
 	EnterpriseID string `gorm:"column:eid" json:"eid"`

--- a/internal/model/cluster.go
+++ b/internal/model/cluster.go
@@ -33,9 +33,9 @@ type RKECluster struct {
 	RainbondInit      bool   `gorm:"column:rainbondInit" json:"rainbondInit,omitempty"`
 	CreateLogPath     string `gorm:"column:createLogPath" json:"createLogPath,omitempty"`
 	// Deprecated
-	NodeList          string `gorm:"column:nodeList;type:text" json:"nodeList,omitempty"`
-	Stats             string `gorm:"column:stats" json:"stats,omitempty"`
-	RKEConfig         string `gorm:"column:rkeConfig"`
+	NodeList  string `gorm:"column:nodeList;type:text" json:"nodeList,omitempty"`
+	Stats     string `gorm:"column:stats" json:"stats,omitempty"`
+	RKEConfig string `gorm:"column:rkeConfig"`
 }
 
 //CustomCluster custom cluster

--- a/internal/repo/rke_cluster_repo.go
+++ b/internal/repo/rke_cluster_repo.go
@@ -21,7 +21,9 @@ package repo
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"goodrain.com/cloud-adaptor/internal/model"
+	"goodrain.com/cloud-adaptor/pkg/bcode"
 	"goodrain.com/cloud-adaptor/pkg/util/uuidutil"
 	"gorm.io/gorm"
 )
@@ -55,7 +57,7 @@ func (t *RKEClusterRepo) Create(te *model.RKECluster) error {
 		}
 		return err
 	}
-	return fmt.Errorf("rke cluster %s is exist", te.Name)
+	return errors.WithStack(bcode.ErrRKEClusterExists)
 }
 
 //Update -

--- a/internal/repo/uitls.go
+++ b/internal/repo/uitls.go
@@ -1,0 +1,26 @@
+// RAINBOND, Application Management Platform
+// Copyright (C) 2020-2020 Goodrain Co., Ltd.
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version. For any non-GPL usage of Rainbond,
+// one or multiple Commercial Licenses authorized by Goodrain Co., Ltd.
+// must be obtained first.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+package repo
+
+import "strings"
+
+func isDuplicateEntry(err error) bool {
+	return strings.HasPrefix(err.Error(), "UNIQUE constraint failed") ||
+		strings.HasPrefix(err.Error(), "Error 1062: Duplicate entry")
+}

--- a/internal/repo/update_kubernetes_task.go
+++ b/internal/repo/update_kubernetes_task.go
@@ -21,7 +21,9 @@ package repo
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"goodrain.com/cloud-adaptor/internal/model"
+	"goodrain.com/cloud-adaptor/pkg/bcode"
 	"goodrain.com/cloud-adaptor/pkg/util/uuidutil"
 	"gorm.io/gorm"
 )
@@ -51,6 +53,9 @@ func (c *UpdateKubernetesTaskRepo) Create(ck *model.UpdateKubernetesTask) error 
 		if err == gorm.ErrRecordNotFound {
 			// not found error, create new
 			if err := c.DB.Save(ck).Error; err != nil {
+				if isDuplicateEntry(err) {
+					return errors.WithStack(bcode.ErrDuplicateKubernetesUpdateTask)
+				}
 				return err
 			}
 			return nil

--- a/internal/usecase/cluster.go
+++ b/internal/usecase/cluster.go
@@ -139,6 +139,16 @@ func (c *ClusterUsecase) CreateKubernetesCluster(eid string, req v1.CreateKubern
 
 	var rkeConfig v3.RancherKubernetesEngineConfig
 	if req.Provider == "rke" {
+		rkeCluster := &model.RKECluster{
+			Name:         req.Name,
+			Stats:        v1alpha1.InitState,
+			EnterpriseID: eid,
+		}
+		// Only the request to successfully create the rke cluster can send the task
+		if err := c.rkeClusterRepo.Create(rkeCluster); err != nil {
+			return nil, err
+		}
+
 		decRKEConfig, err := base64.StdEncoding.DecodeString(req.EncodedRKEConfig)
 		if err != nil {
 			return nil, errors.Wrap(bcode.ErrIncorrectRKEConfig, "decode encoded rke config")

--- a/internal/usecase/cluster.go
+++ b/internal/usecase/cluster.go
@@ -313,7 +313,7 @@ func (c *ClusterUsecase) UpdateKubernetesCluster(eid string, req v1.UpdateKubern
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
-	if lastTask != nil && lastTask.Status == "complete" {
+	if lastTask != nil && lastTask.Status != "complete" {
 		return nil, errors.WithStack(bcode.ErrLastUpdateKuberentesTaskNotComplete)
 	}
 

--- a/pkg/bcode/cluster_bcode.go
+++ b/pkg/bcode/cluster_bcode.go
@@ -66,4 +66,5 @@ var (
 	ErrIncorrectRKEConfig       = newByMessage(400, 7020, "the rke configuration format is incorrect")
 	ErrRKEConfigLost            = newByMessage(404, 7021, "rancher kubernetes engine configuration lost")
 	ErrInitRainbondTaskNotFound = newByMessage(404, 7022, "init rainbond task not found")
+	ErrRKEClusterExists         = newByMessage(409, 7023, "rke cluster already exists")
 )

--- a/pkg/bcode/cluster_bcode.go
+++ b/pkg/bcode/cluster_bcode.go
@@ -63,8 +63,10 @@ var (
 	//ErrorGetRegionStatus -
 	ErrorGetRegionStatus = newByMessage(400, 7019, "can not get region status")
 
-	ErrIncorrectRKEConfig       = newByMessage(400, 7020, "the rke configuration format is incorrect")
-	ErrRKEConfigLost            = newByMessage(404, 7021, "rancher kubernetes engine configuration lost")
-	ErrInitRainbondTaskNotFound = newByMessage(404, 7022, "init rainbond task not found")
-	ErrRKEClusterExists         = newByMessage(409, 7023, "rke cluster already exists")
+	ErrIncorrectRKEConfig                  = newByMessage(400, 7020, "the rke configuration format is incorrect")
+	ErrRKEConfigLost                       = newByMessage(404, 7021, "rancher kubernetes engine configuration lost")
+	ErrInitRainbondTaskNotFound            = newByMessage(404, 7022, "init rainbond task not found")
+	ErrRKEClusterExists                    = newByMessage(409, 7023, "rke cluster already exists")
+	ErrLastUpdateKuberentesTaskNotComplete = newByMessage(409, 7024, "the last kubernetes update task not complete")
+	ErrDuplicateKubernetesUpdateTask       = newByMessage(409, 7025, "kubernetes update task conflict")
 )

--- a/pkg/util/ginutil/ginutil.go
+++ b/pkg/util/ginutil/ginutil.go
@@ -39,7 +39,7 @@ func JSON(c *gin.Context, data interface{}, errs ...error) {
 	}
 	bc := bcode.Err2Coder(err)
 	if bc == bcode.ServerErr {
-		logrus.Errorf("server error: %v", err)
+		logrus.Errorf("server error: %+v", err)
 	}
 	result := &Result{
 		Code: bc.Code(),
@@ -60,7 +60,7 @@ func JSONv2(c *gin.Context, data interface{}, errs ...error) {
 	}
 	bc := bcode.Err2Coder(err)
 	if bc == bcode.ServerErr {
-		logrus.Errorf("server error: %v", err)
+		logrus.Errorf("server error: %+v", err)
 	}
 	if bc.Status() >= 200 && bc.Status() < 300 {
 		c.AbortWithStatusJSON(bc.Status(), data)


### PR DESCRIPTION
发送创建集群任务前, 先把 rke cluster 创建出来, 只有能够成功创建 rke cluster 的请求才可以发送创建集群任务.

避免集群创建任务的多次发送, 并发地创建同一个集群, 可能会导致 rke 报 etcd 容器已存在的问题.