### PR TITLE
Fix Bug: return clusterID when create k8s

### DIFF
--- a/internal/adaptor/rke/rke.go
+++ b/internal/adaptor/rke/rke.go
@@ -45,7 +45,6 @@ import (
 	"goodrain.com/cloud-adaptor/internal/model"
 	"goodrain.com/cloud-adaptor/pkg/bcode"
 	yaml "gopkg.in/yaml.v2"
-	"gorm.io/gorm"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -137,19 +136,9 @@ func (r *rkeAdaptor) CreateRainbondKubernetes(ctx context.Context, eid string, c
 	rollback("InitClusterConfig", "", "start")
 	rkecluster, err := r.Repo.GetCluster(eid, config.ClusterName)
 	if err != nil {
-		if err == gorm.ErrRecordNotFound {
-			rkecluster = &model.RKECluster{
-				Name:         config.ClusterName,
-				Stats:        v1alpha1.InitState,
-				EnterpriseID: eid,
-				ClusterID:    config.ClusterID,
-			}
-			r.Repo.Create(rkecluster)
-		} else {
-			logrus.Errorf("get cluster meta info failure %s", err.Error())
-			rollback("InitClusterConfig", "Get cluster meta info failure", "failure")
-			return nil
-		}
+		logrus.Errorf("get cluster meta info failure %s", err.Error())
+		rollback("InitClusterConfig", "Get cluster meta info failure", "failure")
+		return nil
 	}
 
 	rkeConfig := config.RKEConfig

--- a/internal/adaptor/rke/rke.go
+++ b/internal/adaptor/rke/rke.go
@@ -142,6 +142,7 @@ func (r *rkeAdaptor) CreateRainbondKubernetes(ctx context.Context, eid string, c
 				Name:         config.ClusterName,
 				Stats:        v1alpha1.InitState,
 				EnterpriseID: eid,
+				ClusterID:    config.ClusterID,
 			}
 			r.Repo.Create(rkecluster)
 		} else {

--- a/internal/adaptor/v1alpha1/cluster.go
+++ b/internal/adaptor/v1alpha1/cluster.go
@@ -218,7 +218,6 @@ type KubernetesClusterConfig struct {
 	InstanceType       string                            `json:"instanceType,omitempty"`
 	DockerVersion      string                            `json:"dockerVersion,omitempty"`
 	KubernetesVersion  string                            `json:"kubernetesVersion,omitempty"`
-	ClusterID          string                            `json:"clusterID,omitempty"`
 }
 
 //NodeList node list

--- a/internal/adaptor/v1alpha1/cluster.go
+++ b/internal/adaptor/v1alpha1/cluster.go
@@ -218,6 +218,7 @@ type KubernetesClusterConfig struct {
 	InstanceType       string                            `json:"instanceType,omitempty"`
 	DockerVersion      string                            `json:"dockerVersion,omitempty"`
 	KubernetesVersion  string                            `json:"kubernetesVersion,omitempty"`
+	ClusterID          string                            `json:"clusterID,omitempty"`
 }
 
 //NodeList node list

--- a/internal/model/cloud.go
+++ b/internal/model/cloud.go
@@ -38,6 +38,7 @@ type CreateKubernetesTask struct {
 	EnterpriseID       string `gorm:"column:eid" json:"eid"`
 	TaskID             string `gorm:"column:task_id" json:"taskID"`
 	Status             string `gorm:"column:status" json:"status"`
+	ClusterID          string `gorm:"column:cluster_id" json:"clusterID"`
 }
 
 //InitRainbondTask init rainbond task

--- a/internal/usecase/cluster.go
+++ b/internal/usecase/cluster.go
@@ -145,6 +145,7 @@ func (c *ClusterUsecase) CreateKubernetesCluster(eid string, req v1.CreateKubern
 			Name:         req.Name,
 			Stats:        v1alpha1.InitState,
 			EnterpriseID: eid,
+			ClusterID:    clusterID,
 		}
 		// Only the request to successfully create the rke cluster can send the task
 		if err := c.rkeClusterRepo.Create(rkeCluster); err != nil {
@@ -201,7 +202,6 @@ func (c *ClusterUsecase) CreateKubernetesCluster(eid string, req v1.CreateKubern
 			Region:             newTask.Region,
 			RKEConfig:          &rkeConfig,
 			EnterpriseID:       eid,
-			ClusterID:          clusterID,
 		}}
 	if accessKey != nil {
 		taskReq.KubernetesConfig.AccessKey = accessKey.AccessKey

--- a/internal/usecase/cluster.go
+++ b/internal/usecase/cluster.go
@@ -126,12 +126,14 @@ func (c *ClusterUsecase) CreateKubernetesCluster(eid string, req v1.CreateKubern
 	if c.TaskProducer == nil {
 		return nil, errors.New("TaskProducer is nil")
 	}
+	clusterID := uuidutil.NewUUID()
 	if req.Provider == "custom" {
 		if err := custom.NewCustomClusterRepo(c.DB).Create(&model.CustomCluster{
 			Name:         req.Name,
 			EIP:          strings.Join(req.EIP, ","),
 			KubeConfig:   req.KubeConfig,
 			EnterpriseID: eid,
+			ClusterID:    clusterID,
 		}); err != nil {
 			return nil, errors.Wrap(err, "create custom cluster")
 		}
@@ -172,6 +174,7 @@ func (c *ClusterUsecase) CreateKubernetesCluster(eid string, req v1.CreateKubern
 		EnterpriseID:       eid,
 		Region:             req.Region,
 		TaskID:             uuidutil.NewUUID(),
+		ClusterID:          clusterID,
 	}
 	if err := c.CreateKubernetesTaskRepo.Create(newTask); err != nil {
 		return nil, errors.Wrap(err, "create kubernetes task")
@@ -188,6 +191,7 @@ func (c *ClusterUsecase) CreateKubernetesCluster(eid string, req v1.CreateKubern
 			Region:             newTask.Region,
 			RKEConfig:          &rkeConfig,
 			EnterpriseID:       eid,
+			ClusterID:          clusterID,
 		}}
 	if accessKey != nil {
 		taskReq.KubernetesConfig.AccessKey = accessKey.AccessKey
@@ -760,6 +764,7 @@ func (c *ClusterUsecase) InstallCluster(eid, clusterID string) (*model.CreateKub
 		Provider:     "rke",
 		EnterpriseID: eid,
 		TaskID:       uuidutil.NewUUID(),
+		ClusterID:    clusterID,
 	}
 	if err := c.CreateKubernetesTaskRepo.Create(newTask); err != nil {
 		logrus.Errorf("create kubernetes task failure %s", err.Error())


### PR DESCRIPTION
- When creating a cluster, record the corresponding cluster ID and return it to the front end for optimization prompt