### PR TITLE
Fix Bug: fix column used in key specification without a key length

### DIFF
--- a/internal/model/cloud.go
+++ b/internal/model/cloud.go
@@ -55,7 +55,7 @@ type InitRainbondTask struct {
 type UpdateKubernetesTask struct {
 	Model
 	TaskID    string `gorm:"column:task_id" json:"taskID"`
-	ClusterID string `gorm:"column:cluster_id;uniqueIndex:version;" json:"clusterID"`
+	ClusterID string `gorm:"column:cluster_id;uniqueIndex:version;type:varchar(64)" json:"clusterID"`
 	// Version for optimistic lock
 	Version      int    `gorm:"column:version;uniqueIndex:version;" json:"version"`
 	Provider     string `gorm:"column:provider_name" json:"providerName"`


### PR DESCRIPTION
- Unique index cannot be of type text，Otherwise, an error will be reported when initializing the database：`BLOB/TEXT column used in key specification without a key length`