### PR TITLE
Fix Bug: fix wait rainbond operator timeout

### DIFF
--- a/internal/operator/rainbond_region_init.go
+++ b/internal/operator/rainbond_region_init.go
@@ -34,7 +34,6 @@ import (
 	"github.com/goodrain/rainbond-operator/util/rbdutil"
 	"github.com/goodrain/rainbond-operator/util/retryutil"
 	"github.com/goodrain/rainbond-operator/util/suffixdomain"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"goodrain.com/cloud-adaptor/internal/adaptor/v1alpha1"
 	"goodrain.com/cloud-adaptor/internal/repo"
@@ -108,11 +107,6 @@ func (r *RainbondRegionInit) InitRainbondRegion(initConfig *v1alpha1.RainbondIni
 		return err
 	}
 
-	// make sure ClusterRoleBinding rainbond-operator not exists.
-	if err := r.ensureClusterRoleBinding(client); err != nil {
-		return errors.WithMessage(err, "ensure clusterrolebinding rainbond-operator")
-	}
-
 	// helm create rainbond operator chart
 	defaultArgs := []string{
 		helmPath, "install", "rainbond-operator", chartPath, "-n", r.namespace,
@@ -132,7 +126,7 @@ func (r *RainbondRegionInit) InitRainbondRegion(initConfig *v1alpha1.RainbondIni
 		if err := cmd.Run(); err != nil {
 			errout := stdout.String()
 			if !strings.Contains(errout, "cannot re-use a name that is still in use") {
-				if strings.Contains(errout, "\"rainbond-operator\" already exists") {
+				if strings.Contains(errout, `ClusterRoleBinding "rainbond-operator" in namespace`) {
 					func() {
 						ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 						defer cancel()
@@ -529,25 +523,4 @@ func (r *RainbondRegionInit) UninstallRegion(clusterID string) error {
 			logrus.Debugf("waiting namespace rbd-system deleted")
 		}
 	}
-}
-
-func (r *RainbondRegionInit) ensureClusterRoleBinding(kubeClient kubernetes.Interface) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	crb, err := kubeClient.RbacV1().ClusterRoleBindings().Get(ctx, "rainbond-operator", metav1.GetOptions{})
-	if err != nil {
-		if k8sErrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-
-	if err := kubeClient.RbacV1().ClusterRoleBindings().Delete(ctx, crb.Name, metav1.DeleteOptions{}); err != nil {
-		if k8sErrors.IsNotFound(err) {
-			return nil
-		}
-		return err
-	}
-	return nil
 }

--- a/internal/task/init_rainbond_cluster.go
+++ b/internal/task/init_rainbond_cluster.go
@@ -149,7 +149,7 @@ func (c *InitRainbondCluster) Run(ctx context.Context) {
 		return
 	}
 	ticker := time.NewTicker(time.Second * 5)
-	timer := time.NewTimer(time.Minute * 30)
+	timer := time.NewTimer(time.Minute * 60)
 	defer timer.Stop()
 	defer ticker.Stop()
 	var operatorMessage, imageHubMessage, packageMessage, apiReadyMessage bool


### PR DESCRIPTION
- The cluster role binding relationship resource is not manually deleted during cluster initialization
- Modify the wait time for initializing rainbow to be one hour, which is compatible with the slow timeout of pulling images
- Error message when installing the operator compatible with Helm
> refer to: 
![image](https://user-images.githubusercontent.com/30614084/127438004-70a065cb-4d74-45aa-8b26-046a173c33cd.png)
