### PR TITLE
New Feature: add status 'installing' for  rainbond init task

### DIFF
--- a/cmd/cloud-adaptor/wire_gen.go
+++ b/cmd/cloud-adaptor/wire_gen.go
@@ -61,7 +61,7 @@ func initApp(contextContext context.Context, db *gorm.DB, configConfig *config.C
 	systemHandler := handler.NewSystemHandler(db)
 	router := handler.NewRouter(middlewareMiddleware, clusterHandler, appStoreHandler, systemHandler)
 	createKubernetesTaskHandler := task.NewCreateKubernetesTaskHandler(clusterUsecase)
-	cloudInitTaskHandler := task.NewCloudInitTaskHandler(clusterUsecase)
+	cloudInitTaskHandler := task.NewCloudInitTaskHandler(clusterUsecase, initRainbondTaskRepository)
 	updateKubernetesTaskHandler := task.NewCloudUpdateTaskHandler(clusterUsecase)
 	engine := newApp(contextContext, router, arg, arg2, arg3, createKubernetesTaskHandler, cloudInitTaskHandler, updateKubernetesTaskHandler)
 	return engine, nil

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -665,6 +665,13 @@ var doc = `{
                         "name": "clusterID",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "the provider of the cluster",
+                        "name": "providerName",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -713,6 +720,13 @@ var doc = `{
                         "description": "the name of pod",
                         "name": "podName",
                         "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "the provider of the cluster",
+                        "name": "providerName",
+                        "in": "query",
                         "required": true
                     }
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -653,6 +653,13 @@
                         "name": "clusterID",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "the provider of the cluster",
+                        "name": "providerName",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {
@@ -701,6 +708,13 @@
                         "description": "the name of pod",
                         "name": "podName",
                         "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "the provider of the cluster",
+                        "name": "providerName",
+                        "in": "query",
                         "required": true
                     }
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5166,6 +5166,11 @@ paths:
         name: clusterID
         required: true
         type: string
+      - description: the provider of the cluster
+        in: query
+        name: providerName
+        required: true
+        type: string
       produces:
       - application/json
       responses:
@@ -5197,6 +5202,11 @@ paths:
       - description: the name of pod
         in: path
         name: podName
+        required: true
+        type: string
+      - description: the provider of the cluster
+        in: query
+        name: providerName
         required: true
         type: string
       produces:

--- a/internal/adaptor/custom/custom.go
+++ b/internal/adaptor/custom/custom.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	rainbondv1alpha1 "github.com/goodrain/rainbond-operator/api/v1alpha1"
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"goodrain.com/cloud-adaptor/internal/adaptor"
 	"goodrain.com/cloud-adaptor/internal/adaptor/v1alpha1"
@@ -138,7 +139,7 @@ func (c *customAdaptor) DescribeCluster(eid, clusterID string) (*v1alpha1.Cluste
 func (c *customAdaptor) GetKubeConfig(eid, clusterID string) (*v1alpha1.KubeConfig, error) {
 	cc, err := c.Repo.GetCluster(eid, clusterID)
 	if err != nil {
-		return nil, fmt.Errorf("query cluster meta info failure %s", err.Error())
+		return nil, errors.WithMessage(err, "query cluster meta info failure")
 	}
 	return &v1alpha1.KubeConfig{Config: cc.KubeConfig}, nil
 }

--- a/internal/adaptor/rke/rke.go
+++ b/internal/adaptor/rke/rke.go
@@ -22,16 +22,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"goodrain.com/cloud-adaptor/pkg/util/versionutil"
 	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
 	"time"
 
-	"goodrain.com/cloud-adaptor/internal/repo"
-
 	rainbondv1alpha1 "github.com/goodrain/rainbond-operator/api/v1alpha1"
+	"github.com/pkg/errors"
 	"github.com/rancher/rke/cluster"
 	"github.com/rancher/rke/cmd"
 	"github.com/rancher/rke/hosts"
@@ -44,7 +42,9 @@ import (
 	"goodrain.com/cloud-adaptor/internal/adaptor/v1alpha1"
 	"goodrain.com/cloud-adaptor/internal/datastore"
 	"goodrain.com/cloud-adaptor/internal/model"
+	"goodrain.com/cloud-adaptor/internal/repo"
 	"goodrain.com/cloud-adaptor/pkg/bcode"
+	"goodrain.com/cloud-adaptor/pkg/util/versionutil"
 	yaml "gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/version"
@@ -320,7 +320,7 @@ func converClusterMeta(rkecluster *model.RKECluster) *v1alpha1.Cluster {
 			json.Unmarshal(versionByte, &info)
 			if err == nil {
 				cluster.CurrentVersion = info.String()
-				if !versionutil.CheckVersion(cluster.CurrentVersion){
+				if !versionutil.CheckVersion(cluster.CurrentVersion) {
 					cluster.Parameters["DisableRainbondInit"] = true
 					cluster.Parameters["Message"] = fmt.Sprintf("当前集群版本为 %s ，无法继续初始化，初始化Rainbond支持的版本为1.16.x-1.19.x", cluster.CurrentVersion)
 				}
@@ -559,7 +559,7 @@ func checkAllIncluded(cluster *cluster.Cluster) error {
 func (r *rkeAdaptor) GetKubeConfig(eid, clusterID string) (*v1alpha1.KubeConfig, error) {
 	rkecluster, err := r.Repo.GetCluster(eid, clusterID)
 	if err != nil {
-		return nil, fmt.Errorf("get cluster meta info failure %s", err.Error())
+		return nil, errors.WithMessage(err, "get cluster meta info failure")
 	}
 	if rkecluster.KubeConfig == "" {
 		return nil, fmt.Errorf("not found kube config")

--- a/internal/repo/cloud_task_event.go
+++ b/internal/repo/cloud_task_event.go
@@ -19,6 +19,7 @@
 package repo
 
 import (
+	"github.com/pkg/errors"
 	"goodrain.com/cloud-adaptor/internal/model"
 	"goodrain.com/cloud-adaptor/pkg/util/uuidutil"
 	"gorm.io/gorm"
@@ -75,4 +76,11 @@ func (t *TaskEventRepo) ListEvent(eid, taskID string) ([]*model.TaskEvent, error
 		return nil, err
 	}
 	return list, nil
+}
+
+func (t *TaskEventRepo) UpdateStatusInBatch(eventIDs []string, status string) error {
+	if err := t.DB.Where("event_id in (?)", eventIDs).Updates(&model.TaskEvent{Status: status}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }

--- a/internal/repo/cloud_task_event.go
+++ b/internal/repo/cloud_task_event.go
@@ -78,6 +78,7 @@ func (t *TaskEventRepo) ListEvent(eid, taskID string) ([]*model.TaskEvent, error
 	return list, nil
 }
 
+// UpdateStatusInBatch -
 func (t *TaskEventRepo) UpdateStatusInBatch(eventIDs []string, status string) error {
 	if err := t.DB.Where("event_id in (?)", eventIDs).Updates(&model.TaskEvent{Status: status}).Error; err != nil {
 		return errors.WithStack(err)

--- a/internal/repo/custom_cluster_repo.go
+++ b/internal/repo/custom_cluster_repo.go
@@ -21,7 +21,9 @@ package repo
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
 	"goodrain.com/cloud-adaptor/internal/model"
+	"goodrain.com/cloud-adaptor/pkg/bcode"
 	"goodrain.com/cloud-adaptor/pkg/util/uuidutil"
 	"gorm.io/gorm"
 )
@@ -72,6 +74,9 @@ func (t *CustomClusterRepo) Update(te *model.CustomCluster) error {
 func (t *CustomClusterRepo) GetCluster(eid, name string) (*model.CustomCluster, error) {
 	var rc model.CustomCluster
 	if err := t.DB.Where("eid=? and(name=? or clusterID=?)", eid, name, name).Take(&rc).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.WithStack(bcode.ErrClusterNotFound)
+		}
 		return nil, err
 	}
 	return &rc, nil

--- a/internal/repo/repository.go
+++ b/internal/repo/repository.go
@@ -65,6 +65,7 @@ type TaskEventRepository interface {
 	Transaction(tx *gorm.DB) TaskEventRepository
 	Create(ent *model.TaskEvent) error
 	ListEvent(eid, taskID string) ([]*model.TaskEvent, error)
+	UpdateStatusInBatch(eventIDs []string, status string) error
 }
 
 //RainbondClusterConfigRepository -

--- a/internal/repo/rke_cluster_repo.go
+++ b/internal/repo/rke_cluster_repo.go
@@ -69,6 +69,9 @@ func (t *RKEClusterRepo) Update(te *model.RKECluster) error {
 func (t *RKEClusterRepo) GetCluster(eid, name string) (*model.RKECluster, error) {
 	var rc model.RKECluster
 	if err := t.DB.Where("eid=? and (name=? or clusterID=?)", eid, name, name).Take(&rc).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.WithStack(bcode.ErrClusterNotFound)
+		}
 		return nil, err
 	}
 	return &rc, nil

--- a/internal/task/create_kubernetes.go
+++ b/internal/task/create_kubernetes.go
@@ -84,7 +84,7 @@ func NewCreateKubernetesTaskHandler(clusterUsecase *usecase.ClusterUsecase) Crea
 
 // HandleMsg -
 func (h *createKubernetesTaskHandler) HandleMsg(ctx context.Context, createConfig types.KubernetesConfigMessage) error {
-	initTask, err := CreateTask(CreateKubernetesTask, createConfig.KubernetesConfig)
+	initTask, err := CreateTask(CreateKubernetesTask, createConfig.KubernetesConfig, nil)
 	if err != nil {
 		logrus.Errorf("create task failure %s", err.Error())
 		h.eventHandler.HandleEvent(createConfig.GetEvent(&v1.Message{

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/wire"
 	v1 "goodrain.com/cloud-adaptor/api/cloud-adaptor/v1"
 	"goodrain.com/cloud-adaptor/internal/adaptor/v1alpha1"
+	"goodrain.com/cloud-adaptor/internal/repo"
 	"goodrain.com/cloud-adaptor/internal/types"
 )
 
@@ -50,7 +51,7 @@ var UpdateKubernetesTask Type = "update_kubernetes"
 var InitRainbondClusterTask Type = "init_rainbond_cluster"
 
 //CreateTask create task
-func CreateTask(taskType Type, config interface{}) (Task, error) {
+func CreateTask(taskType Type, config interface{}, initRainbondTaskRepo repo.InitRainbondTaskRepository) (Task, error) {
 	switch taskType {
 	case CreateKubernetesTask:
 		cconfig, ok := config.(*v1alpha1.KubernetesClusterConfig)
@@ -63,7 +64,7 @@ func CreateTask(taskType Type, config interface{}) (Task, error) {
 		if !ok {
 			return nil, fmt.Errorf("config must be *InitRainbondConfig")
 		}
-		return &InitRainbondCluster{result: make(chan v1.Message, 10), config: cconfig}, nil
+		return &InitRainbondCluster{result: make(chan v1.Message, 10), config: cconfig, initRainbondTaskRepo: initRainbondTaskRepo}, nil
 	case UpdateKubernetesTask:
 		cconfig, ok := config.(*v1alpha1.ExpansionNode)
 		if !ok {

--- a/internal/task/update_kubernetes.go
+++ b/internal/task/update_kubernetes.go
@@ -29,8 +29,8 @@ import (
 	v1 "goodrain.com/cloud-adaptor/api/cloud-adaptor/v1"
 	"goodrain.com/cloud-adaptor/internal/adaptor/factory"
 	"goodrain.com/cloud-adaptor/internal/adaptor/v1alpha1"
-	"goodrain.com/cloud-adaptor/internal/usecase"
 	"goodrain.com/cloud-adaptor/internal/types"
+	"goodrain.com/cloud-adaptor/internal/usecase"
 	"goodrain.com/cloud-adaptor/pkg/util/constants"
 )
 
@@ -86,7 +86,7 @@ func (h *cloudUpdateTaskHandler) HandleMsg(ctx context.Context, config types.Upd
 		logrus.Infof("task %s is running or complete,ignore", config.TaskID)
 		return nil
 	}
-	initTask, err := CreateTask(UpdateKubernetesTask, config.Config)
+	initTask, err := CreateTask(UpdateKubernetesTask, config.Config, nil)
 	if err != nil {
 		logrus.Errorf("create task failure %s", err.Error())
 		h.eventHandler.HandleEvent(config.GetEvent(&v1.Message{

--- a/internal/types/message.go
+++ b/internal/types/message.go
@@ -30,6 +30,7 @@ type InitRainbondConfig struct {
 	AccessKey    string `json:"access_key"`
 	SecretKey    string `json:"secret_key"`
 	Provider     string `json:"provider"`
+	TaskID       string `json:"task_id"`
 }
 
 //KubernetesConfigMessage nsq message


### PR DESCRIPTION
为了防止对已安装了 rainbond-operator 的集群进行重新安装, 添加了新状态 'installing'.

创建 rainbond-operator 之后, 状态由 start 变为 'installing'. 这时, 是不能重新安装的, 只有状态为 complete 才能重新安装.

对于处于 installing 状态的任务, 如果某个 event 失败了, 任务仍然是 installing, 不再是 complete.

每次查询 event 列表时, 会去同步集群的状态, 将安装成功的状态同步回来.