### PR TITLE
New Feature: check if rainbond cluster already installed

### DIFF
--- a/internal/adaptor/v1alpha1/cluster.go
+++ b/internal/adaptor/v1alpha1/cluster.go
@@ -513,11 +513,12 @@ type LoadBalancer struct {
 
 //RainbondRegionStatus rainbond region status
 type RainbondRegionStatus struct {
-	OperatorReady   bool
-	RainbondCluster *rainbondv1alpha1.RainbondCluster
-	RainbondPackage *rainbondv1alpha1.RainbondPackage
-	RainbondVolume  *rainbondv1alpha1.RainbondVolume
-	RegionConfig    *v1.ConfigMap
+	OperatorReady     bool
+	OperatorInstalled bool
+	RainbondCluster   *rainbondv1alpha1.RainbondCluster
+	RainbondPackage   *rainbondv1alpha1.RainbondPackage
+	RainbondVolume    *rainbondv1alpha1.RainbondVolume
+	RegionConfig      *v1.ConfigMap
 }
 
 //AvailableResourceZone available resource

--- a/internal/handler/cluster.go
+++ b/internal/handler/cluster.go
@@ -386,7 +386,7 @@ func (e *ClusterHandler) CreateInitRainbondTask(ctx *gin.Context) {
 		ginutil.JSON(ctx, nil, bcode.BadRequest)
 		return
 	}
-	task, err := e.cluster.InitRainbondRegion(eid, req)
+	task, err := e.cluster.InitRainbondRegion(ctx.Request.Context(), eid, req)
 	if err != nil {
 		ginutil.JSON(ctx, task, err)
 		return

--- a/internal/operator/rainbond_region_init.go
+++ b/internal/operator/rainbond_region_init.go
@@ -383,6 +383,9 @@ func (r *RainbondRegionInit) GetRainbondRegionStatus(clusterID string) (*v1alpha
 	if deployment != nil && deployment.Status.ReadyReplicas >= 1 {
 		status.OperatorReady = true
 	}
+	if deployment != nil {
+		status.OperatorInstalled = true
+	}
 	var cluster rainbondv1alpha1.RainbondCluster
 	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel2()

--- a/internal/repo/cloud_task_event.go
+++ b/internal/repo/cloud_task_event.go
@@ -19,6 +19,7 @@
 package repo
 
 import (
+	"github.com/pkg/errors"
 	"goodrain.com/cloud-adaptor/internal/model"
 	"goodrain.com/cloud-adaptor/pkg/util/uuidutil"
 	"gorm.io/gorm"
@@ -75,4 +76,12 @@ func (t *TaskEventRepo) ListEvent(eid, taskID string) ([]*model.TaskEvent, error
 		return nil, err
 	}
 	return list, nil
+}
+
+// UpdateStatusInBatch -
+func (t *TaskEventRepo) UpdateStatusInBatch(eventIDs []string, status string) error {
+	if err := t.DB.Where("event_id in (?)", eventIDs).Updates(&model.TaskEvent{Status: status}).Error; err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }

--- a/internal/repo/repository.go
+++ b/internal/repo/repository.go
@@ -65,6 +65,7 @@ type TaskEventRepository interface {
 	Transaction(tx *gorm.DB) TaskEventRepository
 	Create(ent *model.TaskEvent) error
 	ListEvent(eid, taskID string) ([]*model.TaskEvent, error)
+	UpdateStatusInBatch(eventIDs []string, status string) error
 }
 
 //RainbondClusterConfigRepository -

--- a/pkg/bcode/cluster_bcode.go
+++ b/pkg/bcode/cluster_bcode.go
@@ -70,4 +70,6 @@ var (
 	ErrDuplicateKubernetesUpdateTask = newByMessage(409, 7025, "kubernetes update task conflict")
 	ErrLastTaskNotFound              = newByMessage(404, 7026, "update kubernetes task not found")
 	ErrClusterNotFound               = newByMessage(404, 7027, "cluster not found")
+
+	ErrRainbondClusterInstalled = newByMessage(409, 7028, "rainbond cluster is already installed")
 )


### PR DESCRIPTION
1. 安装 rainbond 集群前检查是否已经创建了 rainbond-operator
2. 根据集群的实际状态决定任务的状态是否为 intalling.
3. 查询事件时, 主动更新事件的状态, 将失败的事件更新为成功