### PR TITLE
bug fix: wrong condition for installed

### DIFF
--- a/api/cloud-adaptor/v1/cluster.go
+++ b/api/cloud-adaptor/v1/cluster.go
@@ -267,7 +267,7 @@ type ByRainbondComponentPodPhase []*RainbondComponent
 func (a ByRainbondComponentPodPhase) Len() int      { return len(a) }
 func (a ByRainbondComponentPodPhase) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a ByRainbondComponentPodPhase) Less(i, j int) bool {
-	return a.phaseScore(i) < a.phaseScore(j)
+	return a.phaseScore(i) > a.phaseScore(j)
 }
 
 func (a ByRainbondComponentPodPhase) phaseScore(i int) int {


### PR DESCRIPTION
1. 按照pod的phase降序排序
2. deployment 不存在时, Deployments(constants.Namespace).Get() 会返回空的 deployment, 不能根据 deployment == nil 判断 是否已经安装 rainbond-operator.