### PR TITLE
perf: remove k3s containerd mount

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -28,12 +28,6 @@ spec:
           hostPath:
             path: /run
             type: Directory
-        {{- if .Values.operator.isDind }}
-        - name: containerdsock
-          hostPath:
-            path: /run/k3s/containerd
-            type: Directory
-        {{- end }}
       containers:
         - command:
             - /manager
@@ -73,9 +67,5 @@ spec:
               name: vardir
             - mountPath: /run
               name: rundir
-          {{- if .Values.operator.isDind }}
-            - mountPath: /run/containerd
-              name: containerdsock
-          {{- end }}
       terminationGracePeriodSeconds: 10
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -23,4 +23,3 @@ operator:
     pullPolicy: IfNotPresent
   regionDBName: region
   logLevel: 4
-  isDind: false


### PR DESCRIPTION
dind 版本不再使用 k3s 内置的 containerd，使用新安装的 containerd，因此挂载路径不需要特殊处理